### PR TITLE
Persist activities and registrations with SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Hey kvkang!
 
 Mona here. I'm done preparing your exercise. Hope you enjoy! 💚
 
+This project now uses SQLite-backed persistence for activities and registrations in `src/activities.sqlite`.
+
 Remember, it's self-paced so feel free to take a break! ☕️
 
 [![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/kvkang/skills-integrate-mcp-with-copilot/issues/1)

--- a/src/README.md
+++ b/src/README.md
@@ -6,13 +6,15 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister from activities
+- Persistent SQLite storage for activities and registrations
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
@@ -47,4 +49,6 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+Data is stored in a local SQLite database at `src/activities.sqlite`, so activity and registration data persists across server restarts.
+
+On first run, the API seeds the database with the default activities and starter registrations.

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import sqlite3
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,8 +20,9 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+DB_PATH = current_dir / "activities.sqlite"
+
+DEFAULT_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -78,6 +80,99 @@ activities = {
 }
 
 
+def get_connection() -> sqlite3.Connection:
+    connection = sqlite3.connect(DB_PATH)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def initialize_database() -> None:
+    with get_connection() as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                name TEXT PRIMARY KEY,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL CHECK(max_participants > 0)
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS registrations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                activity_name TEXT NOT NULL,
+                email TEXT NOT NULL,
+                UNIQUE(activity_name, email),
+                FOREIGN KEY(activity_name) REFERENCES activities(name) ON DELETE CASCADE
+            )
+            """
+        )
+
+        existing_count = connection.execute(
+            "SELECT COUNT(*) AS total FROM activities"
+        ).fetchone()["total"]
+
+        # Seed baseline data only when the DB is brand new.
+        if existing_count == 0:
+            for name, details in DEFAULT_ACTIVITIES.items():
+                connection.execute(
+                    """
+                    INSERT INTO activities (name, description, schedule, max_participants)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (name, details["description"], details["schedule"], details["max_participants"]),
+                )
+                for email in details["participants"]:
+                    connection.execute(
+                        """
+                        INSERT INTO registrations (activity_name, email)
+                        VALUES (?, ?)
+                        """,
+                        (name, email),
+                    )
+
+
+def load_activities() -> dict[str, dict]:
+    with get_connection() as connection:
+        activity_rows = connection.execute(
+            """
+            SELECT name, description, schedule, max_participants
+            FROM activities
+            ORDER BY name
+            """
+        ).fetchall()
+
+        registrations_rows = connection.execute(
+            """
+            SELECT activity_name, email
+            FROM registrations
+            ORDER BY activity_name, id
+            """
+        ).fetchall()
+
+    participants_by_activity: dict[str, list[str]] = {}
+    for row in registrations_rows:
+        participants_by_activity.setdefault(row["activity_name"], []).append(row["email"])
+
+    activities: dict[str, dict] = {}
+    for row in activity_rows:
+        activity_name = row["name"]
+        activities[activity_name] = {
+            "description": row["description"],
+            "schedule": row["schedule"],
+            "max_participants": row["max_participants"],
+            "participants": participants_by_activity.get(activity_name, []),
+        }
+
+    return activities
+
+
+initialize_database()
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -85,48 +180,69 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return load_activities()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as connection:
+        activity = connection.execute(
+            "SELECT name, max_participants FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+        existing_registration = connection.execute(
+            """
+            SELECT 1
+            FROM registrations
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email),
+        ).fetchone()
+        if existing_registration is not None:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
+
+        participant_count = connection.execute(
+            "SELECT COUNT(*) AS total FROM registrations WHERE activity_name = ?",
+            (activity_name,),
+        ).fetchone()["total"]
+        if participant_count >= activity["max_participants"]:
+            raise HTTPException(status_code=400, detail="Activity is full")
+
+        connection.execute(
+            "INSERT INTO registrations (activity_name, email) VALUES (?, ?)",
+            (activity_name, email),
         )
 
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as connection:
+        activity = connection.execute(
+            "SELECT 1 FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        result = connection.execute(
+            """
+            DELETE FROM registrations
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email),
         )
+        if result.rowcount == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity"
+            )
 
-    # Remove student
-    activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
- replace in-memory activity storage with SQLite-backed persistence
- create `activities` and `registrations` tables with first-run seeding
- keep existing API response shape for `GET /activities`
- preserve duplicate signup checks and enforce capacity checks before inserts
- update project docs to describe persistent storage behavior

## Validation
- executed function-level checks for listing activities, signup, duplicate signup rejection, unregister, and duplicate unregister rejection

## Related issue
- Closes #8